### PR TITLE
Fixed rope check.

### DIFF
--- a/WandasGizmos/src/EntityHook.cs
+++ b/WandasGizmos/src/EntityHook.cs
@@ -224,7 +224,7 @@ namespace WandasGizmos
             }
             foreach (ItemSlot itemSlot in FiredBy.Player.InventoryManager.GetHotbarInventory())
             {
-                if (itemSlot?.Itemstack?.GetName() == "Rope")
+                if (itemSlot?.Itemstack?.Item.Code.ToString() == "game:rope")
                 {
                     RopeCount += itemSlot.Itemstack.StackSize * 3 / 2;
                 }

--- a/WandasGizmos/src/ItemGrapplingHook.cs
+++ b/WandasGizmos/src/ItemGrapplingHook.cs
@@ -104,7 +104,7 @@ namespace WandasGizmos
             ItemRopeCount = 0;
             foreach (ItemSlot itemSlot in FiredBy.Player.InventoryManager.GetHotbarInventory())
             {
-                if (itemSlot?.Itemstack?.GetName() == "Rope")
+                if (itemSlot?.Itemstack?.Item.Code.ToString() == "game:rope")
                 {
                     ItemRopeCount += itemSlot.Itemstack.StackSize;
                 }


### PR DESCRIPTION
Itemstack?.GetName() == "Rope")
compares the localized name. That is, it only works with English localization. In my version, verification is done using in-game code. it should not change, unlike the id and name.